### PR TITLE
Added NRPE monitoring for cluster partition state

### DIFF
--- a/scripts/check_rabbitmq_cluster.py
+++ b/scripts/check_rabbitmq_cluster.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+"""
+Nagios check to check RabbitMQ cluster for partitioning (split-brain)
+"""
+
+import argparse
+import sys
+import os.path
+import time
+import re
+
+
+OK = 0
+WARNING = 1
+CRITICAL = 2
+UNKNOWN = 3
+
+parser = argparse.ArgumentParser(description='RabbitMQ cluster state check for Nagios.')
+parser.add_argument('statsfile', nargs=1, type=str, help='file containing cluster status')
+parser.add_argument('--freshness', nargs=1, type=int, required=False, default=300, help='update frequency of stats file in seconds, defaults to 300s')
+args = parser.parse_args()
+
+try:
+    if time.time() - os.path.getmtime(args.statsfile[0]) > args.freshness:
+        print 'CRITICAL - Cluster state file is too old'
+        sys.exit(CRITICAL)
+    data = ""
+    with open(args.statsfile[0]) as fh:
+        for line in fh:
+            data += line.rstrip('\n')
+    if not data:
+        print 'UNKNOWN - Missing data for RabbitMQ cluster state'
+        sys.exit(UNKNOWN)
+    if not re.search('\{partitions,\[\]\}', data):
+        print 'CRITICAL - Multiple partitions detected'
+        sys.exit(CRITICAL)
+    else:
+        print 'OK - No partitioning detected'
+        sys.exit(OK)
+except Exception as e:
+    print "UNKNOWN - Error during check processing: %s" % str(e)
+    sys.exit(UNKNOWN)

--- a/scripts/rabbitmq_cluster_state.sh
+++ b/scripts/rabbitmq_cluster_state.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+DATA_DIR="/var/lib/rabbitmq/data"
+HOSTNAME=$(hostname -s)
+DATA_FILE="${DATA_DIR}/${HOSTNAME}_cluster_state.dat"
+TMP_FILE=$(mktemp -p ${DATA_DIR})
+
+trap "rm -f $TMP_FILE > /dev/null 2>&1" EXIT
+
+/usr/sbin/rabbitmqctl -q cluster_status >$TMP_FILE 2>/dev/null
+if [ $? -eq 0 ]; then
+    chown rabbitmq:rabbitmq ${TMP_FILE}
+    chmod 0644 ${TMP_FILE}
+    mv ${TMP_FILE} ${DATA_FILE}
+else
+    rm -f $TMP_FILE
+fi
+
+trap - EXIT


### PR DESCRIPTION
The current RabbitMQ charm does not have built-in monitoring for the RabbitMQ cluster partition state.

This feature was requested by our operations team, but also in https://bugs.launchpad.net/charm-rabbitmq-server/+bug/1548679

The implementation in this merge request is very similar to the existing queue length monitoring. The cluster state is retrieved by running plain rabbitmqctl from cron as root, output is saved into a data file that is checked by the nrpe plugin script.

Other option could be to use the Management API, but in our environment it is not enabled.