### PR TITLE
[Fix]: Fixed alert failure in check_rabbitmq_cluster

### DIFF
--- a/files/check_rabbitmq_cluster.py
+++ b/files/check_rabbitmq_cluster.py
@@ -99,8 +99,8 @@ if __name__ == '__main__':
 
     if (partitions > 0 or cluster < 0):
         print(
-            "CRITICAL: %d partitions detected, %d nodes online."
-        ) % (partitions, cluster)
+            "CRITICAL: %d partitions detected, %d nodes online." % (partitions, cluster)
+        )
         sys.exit(2)
     else:
         print("OK: No partitions detected")


### PR DESCRIPTION
See bug report on launchpad [here](https://bugs.launchpad.net/charm-rabbitmq-server/+bug/2080883).

Summary: Mal-formatted print string statement caused failure to both notify/alert user on downed rabbitmq cluster and prevented them from checking the status while down

Fixed by placing the string substitution inside the print statement